### PR TITLE
Fixed bug in updatedisplay() function

### DIFF
--- a/script.js
+++ b/script.js
@@ -100,7 +100,7 @@ function undoAnswer() {
  */
 
 function updateDisplay() {
-  if (gameState.currentQuestion === 1) {
+  if (gameState.currentQuestion === 0) {
     showScreen(startScreen);
   } else if (gameState.currentQuestion > 0 && gameState.currentQuestion < 10) {
     showScreen(questionBox);


### PR DESCRIPTION
The condition should that on question 0 (before the quiz starts) that the showScreen() function is called, not on question 1.